### PR TITLE
aotf: don't shortlist state-disabled mutations

### DIFF
--- a/src/components/cylc/cylcObject/Menu.vue
+++ b/src/components/cylc/cylcObject/Menu.vue
@@ -196,11 +196,15 @@ export default {
       }
       const shortList = this.primaryMutations
       if (!this.expanded && shortList.length) {
-        return this.mutations.filter(
-          x => shortList.includes(x.mutation.name)
-        ).sort(
-          (x, y) => shortList.indexOf(x.mutation.name) - shortList.indexOf(y.mutation.name)
-        )
+        return this.mutations
+          // filter for shortlisted mutations
+          .filter(x => shortList.includes(x.mutation.name))
+          // filter out mutations which aren't relevant to the workflow state
+          .filter(x => !this.isDisabled(x.mutation, true))
+          // sort by definition order
+          .sort(
+            (x, y) => shortList.indexOf(x.mutation.name) - shortList.indexOf(y.mutation.name)
+          )
       }
       return this.mutations
     },

--- a/src/utils/aotf.js
+++ b/src/utils/aotf.js
@@ -168,6 +168,7 @@ export const cylcObjects = Object.freeze({
 export const primaryMutations = {
   [cylcObjects.Workflow]: [
     'play',
+    'resume',
     'pause',
     'stop',
     'reload',


### PR DESCRIPTION
* If a mutation is not relevant for the workflow state, don't show it.
* Add `resume` to the shortlisted workflow mutations so that either resume or play is visible for all workflows.
